### PR TITLE
Cleanup: removed misplaced 'Forgot Password' link on signup

### DIFF
--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -132,15 +132,6 @@ export default function SignupPage() {
                 />
               )}
             </div>
-
-            <div className="text-right mt-2">
-              <Link
-                href="#"
-                className="text-sm text-gray-500 hover:text-gray-700"
-              >
-                Forgot password?
-              </Link>
-            </div>
           </div>
 
           <Button


### PR DESCRIPTION
# Pull Request  

## **Description**  
Removed the **"Forgot Password"** link from the **Create Account** page.  
This link is only relevant for login, not for new account creation, and was confusing in its previous placement.  

## **Type of change**  
- [x] Bug fix (non-breaking change which fixes an issue)   

## **Checklist**  
- [x] I have performed a self-review of my own code  
- [x] I have commented my code where necessary  
- [x] I have removed redundant UI elements  
- [x] My changes generate no new warnings  

## **Related Issues**  
Closes #79 

## Screenshot:
**Before**
<img width="556" height="844" alt="Screenshot 2025-08-18 161722" src="https://github.com/user-attachments/assets/29ede23d-9af1-4d7b-b338-1afc8c3b8a09" />
**After**
<img width="776" height="903" alt="Screenshot 2025-08-19 113318" src="https://github.com/user-attachments/assets/f007d222-8e14-4c77-92a8-74c514bf3a81" />
 

