### PR TITLE
Fix: Sidebar visible in Help and Contact Us modal

### DIFF
--- a/src/app/help/layout.tsx
+++ b/src/app/help/layout.tsx
@@ -1,0 +1,12 @@
+"use client";
+import React from "react";
+import Sidebar from "@/components/Sidebar";
+
+export default function HelpLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex h-screen bg-gray-100">
+      <Sidebar />
+      <div className="flex-1 flex flex-col">{children}</div>
+    </div>
+  );
+}

--- a/src/app/help/page.tsx
+++ b/src/app/help/page.tsx
@@ -1,4 +1,5 @@
-'use client';
+"use client";
+import React from "react";
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -54,6 +55,11 @@ export default function HelpCenterPage() {
     },
   ];
 
+  const [showModal, setShowModal] = React.useState(false);
+
+  const handleContactClick = () => setShowModal(true);
+  const handleCloseModal = () => setShowModal(false);
+
   return (
     <div className="p-8 bg-gray-50 min-h-screen">
       <div className="text-center mb-12">
@@ -95,8 +101,29 @@ export default function HelpCenterPage() {
         <p className="text-gray-600 mb-4">
           Reach out to our team for support on setup, filings, or tailored automation.
         </p>
-        <Button className="bg-green-700 hover:bg-green-800 text-white px-6 py-2">Contact Us</Button>
+        <Button className="bg-green-700 hover:bg-green-800 text-white px-6 py-2" onClick={handleContactClick}>Contact Us</Button>
       </div>
+
+      {showModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40">
+          <div className="bg-white rounded-lg shadow-lg p-8 w-full max-w-md relative">
+            <button
+              className="absolute top-2 right-2 text-gray-500 hover:text-gray-700"
+              onClick={handleCloseModal}
+              aria-label="Close"
+            >
+              &times;
+            </button>
+            <h2 className="text-xl font-bold mb-4 text-green-800">Contact Us</h2>
+            <form className="space-y-4">
+              <Input type="text" placeholder="Your Name" required />
+              <Input type="email" placeholder="Your Email" required />
+              <textarea className="w-full p-2 border rounded" rows={4} placeholder="How can we help you?" required />
+              <Button type="submit" className="bg-green-700 hover:bg-green-800 text-white w-full">Send Message</Button>
+            </form>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
# Pull Request

**Description**
This PR ensures the vertical navigation bar (Sidebar) remains visible on the Help page and makes the "Contact Us" button functional by opening a contact modal. This improves user experience and navigation consistency.

**Type of change**
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

**Checklist**
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have added tests where necessary
- [x] My changes generate no new warnings

**Related Issues**
Closes #91 

---